### PR TITLE
Update charter post IESG consideration

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -1,7 +1,7 @@
-# Draft Charter for Media over QUIC
+#Charter for Media over QUIC
 
 Media over QUIC (moq) will develop a simple low-latency media delivery solution
-for ingest and distribution of media.  This solution may address use cases including live
+for ingest and distribution of media.  This solution addresses use cases including live
 streaming, gaming, and media conferencing and will scale efficiently. The
 solution will be implementable in both browser and non-browser endpoints.
 
@@ -15,7 +15,7 @@ The common protocol for publishing media for ingest and distribution
 will support:
 
 * one or more media formats,
-* an interoperable way to request media and encodings,
+* an interoperable way to indicate the media and the media format being sent,
 * rate adaptation strategies based on changing codec rates, changing chosen media
 encoding/qualities, or other mechanisms
 * cache friendly media mechanisms
@@ -29,12 +29,11 @@ Media will be mapped onto underlying QUIC mechanisms (QUIC streams and/or
 QUIC datagrams) and can be used over raw QUIC or WebTransport.
 
 The proposed solution will provide extensibility for supporting different media
-formats and shall specify a mandatory to implement media format to ensure
-interoperability. The proposed solution will support multiple media types and media encodings.
+formats and will support multiple media types and media encodings.
 
 
 The working group will define MoQ so that the media publication protocol 
-can leverage coodinating relays, caches, or replication points wherever applicable 
+can leverage coordinating relays, caches, or replication points wherever applicable 
 to improve the delivery performance.
 
 The solution will specify a simple method for clients to authenticate
@@ -42,7 +41,7 @@ to the relay or server to transmit or receive media.
 Media will be encrypted at the transport layer using the standard QUIC
 mechanisms.  Media content may be end-to-end encrypted in certain use cases,
 where the "end-to-end" keys are available to media sources and consumers, but
-not relays.  Even when media is end-to-end encrypted, the relays can access
+not relays.  Even when media is content end-to-end encrypted, the relays can access
 metadata needed for caching (such as timestamp), making media forwarding
 decisions (such as drop or delay under congestion), and so on.  Such media
 metadata will be authenticated and integrity-protected end-to-end.  Mechanisms
@@ -62,7 +61,7 @@ W3C WebTransport as appropriate.
 
 * WG adoption of Protocol Specification for Common Media Publication Protocol
 over QUIC
-* WG adoption of Protocol Specification for Datagram Extension to Media
+* WG adoption of Protocol Specification for the use of the Datagram Extension for Media
 Publication Protocol over QUIC
 * WG adoption of Protocol Specification for Media Subscription Protocol over
 QUIC
@@ -73,7 +72,7 @@ Protocol over QUIC
 WG consensus
 * Forward Protocol Specification for Common Media Publication Protocol over QUIC
 draft to IESG
-* Forward Protocol Specification for Datagram Extension to Media Publication
+* Forward Protocol Specification for the use of the Datagram Extension for Media Publication
 Protocol over QUIC draft to IESG
 * Forward Protocol Specification for Media Subscription Protocol over QUIC draft
 to IESG


### PR DESCRIPTION
This incorporates the changes proposed #63, #64, and #68, removes the Mandatory-to-Implement section as discussed on the mailing lists, and makes the required changes to address the Block from the IESG charter discussion.

It does not address #66, Spencer's suggestion to drop the Architecture documents, or his suggestion that we specify of MoQ-capable in front of relays (and similar).